### PR TITLE
Parameterize absent pr name

### DIFF
--- a/controllers/absence_prometheusrule.go
+++ b/controllers/absence_prometheusrule.go
@@ -38,31 +38,20 @@ const absencePromRuleNameSuffix = "-absent-metric-alert-rules"
 // holds the absence alert rules concerning a specific Prometheus server (e.g. openstack, kubernetes, etc.).
 func AbsencePrometheusRuleName(prometheusRule monitoringv1.PrometheusRule, prometheusRuleString string) string {
 
-	//fmt.Printf("%+v\n", prometheusRule)
-
-	t := template.Must(template.New("sampleTest").Parse(prometheusRuleString))
+	t := template.Must(template.New("PrometheusRuleTemplate").Parse(prometheusRuleString))
 	b, err := json.Marshal(prometheusRule)
 
 	m := make(map[string]interface{})
 	err = json.Unmarshal(b, &m)
 
-	fmt.Println("After unmarshall")
-	fmt.Println(m)
-
 	buf := &bytes.Buffer{}
-	//err := t.Execute(buf, prometheusRule)
 	err = t.Execute(buf, m)
 	if err != nil {
 		fmt.Println(err.Error())
 		return "default-absent-metrics"
 	}
 
-
-	fmt.Println("Generated absence rule name:")
-	fmt.Println(buf.String())
 	return buf.String()
-
-	//return fmt.Sprintf("%s%s", promServer, absencePromRuleNameSuffix)
 }
 
 func (r *PrometheusRuleReconciler) newAbsencePrometheusRule(namespace, name string, promServer string) *monitoringv1.PrometheusRule {
@@ -240,9 +229,6 @@ func (r *PrometheusRuleReconciler) cleanUpAbsencePrometheusRule(ctx context.Cont
 	// concerning Prometheus server.
 	var listOpts client.ListOptions
 	client.InNamespace(absencePromRule.GetNamespace()).ApplyToList(&listOpts)
-	//client.MatchingLabels{
-	//	labelPrometheusServer: absencePromRule.Labels[labelPrometheusServer],
-	//}.ApplyToList(&listOpts)
 	var promRules monitoringv1.PrometheusRuleList
 	if err := r.List(ctx, &promRules, &listOpts); err != nil {
 		return err

--- a/controllers/absence_prometheusrule.go
+++ b/controllers/absence_prometheusrule.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"bytes"
+	"encoding/json"
 )
 
 const absencePromRuleNameSuffix = "-absent-metric-alert-rules"
@@ -40,12 +41,22 @@ func AbsencePrometheusRuleName(prometheusRule monitoringv1.PrometheusRule, prome
 	//fmt.Printf("%+v\n", prometheusRule)
 
 	t := template.Must(template.New("sampleTest").Parse(prometheusRuleString))
+	b, err := json.Marshal(prometheusRule)
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(b, &m)
+
+	fmt.Println("After unmarshall")
+	fmt.Println(m)
+
 	buf := &bytes.Buffer{}
-	err := t.Execute(buf, prometheusRule)
+	//err := t.Execute(buf, prometheusRule)
+	err = t.Execute(buf, m)
 	if err != nil {
-		//fmt.Println(err.Error())
+		fmt.Println(err.Error())
 		return "default-absent-metrics"
 	}
+
 
 	fmt.Println("Generated absence rule name:")
 	fmt.Println(buf.String())

--- a/controllers/absence_prometheusrule.go
+++ b/controllers/absence_prometheusrule.go
@@ -204,9 +204,9 @@ func (r *PrometheusRuleReconciler) cleanUpAbsencePrometheusRule(ctx context.Cont
 	// concerning Prometheus server.
 	var listOpts client.ListOptions
 	client.InNamespace(absencePromRule.GetNamespace()).ApplyToList(&listOpts)
-	client.MatchingLabels{
-		labelPrometheusServer: absencePromRule.Labels[labelPrometheusServer],
-	}.ApplyToList(&listOpts)
+	//client.MatchingLabels{
+	//	labelPrometheusServer: absencePromRule.Labels[labelPrometheusServer],
+	//}.ApplyToList(&listOpts)
 	var promRules monitoringv1.PrometheusRuleList
 	if err := r.List(ctx, &promRules, &listOpts); err != nil {
 		return err
@@ -252,7 +252,8 @@ func (r *PrometheusRuleReconciler) updateAbsenceAlertRules(ctx context.Context, 
 	promServer, ok := promRuleLabels["prometheus"]
 	if !ok {
 		// Normally this shouldn't happen but just in case that it does.
-		return errors.New("no 'prometheus' label found")
+		promServer = "default-prometheus"
+		// return errors.New("no 'prometheus' label found")
 	}
 
 	// Step 2: get the corresponding AbsencePrometheusRule if it exists. We do this in

--- a/controllers/prometheusrule_controller.go
+++ b/controllers/prometheusrule_controller.go
@@ -50,6 +50,7 @@ type PrometheusRuleReconciler struct {
 	// KeepLabel is a map of labels that will be retained from the original alert rule and
 	// passed on to its corresponding absent alert rule.
 	KeepLabel KeepLabel
+	PrometheusRuleString string
 }
 
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
@@ -67,10 +68,10 @@ func (r *PrometheusRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	err := r.Get(ctx, req.NamespacedName, &promRule)
 	switch {
 	case err == nil:
-		err = r.reconcileObject(ctx, req.NamespacedName, &promRule)
+		err = r.reconcileObject(ctx, req.NamespacedName, &promRule, r.PrometheusRuleString)
 	case apierrors.IsNotFound(err):
 		// Could not find object on the API server, maybe it has been deleted?
-		return r.handleObjectNotFound(ctx, req.NamespacedName)
+		return r.handleObjectNotFound(ctx, req.NamespacedName, r.PrometheusRuleString)
 	default:
 		// Handle err down below.
 	}
@@ -103,7 +104,7 @@ func (r *PrometheusRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // handleObjectNotFound is a helper function for Reconcile(). It exists separately so that
 // we can exit on error without making the `switch` in Reconcile() complex.
-func (r *PrometheusRuleReconciler) handleObjectNotFound(ctx context.Context, key types.NamespacedName) (ctrl.Result, error) {
+func (r *PrometheusRuleReconciler) handleObjectNotFound(ctx context.Context, key types.NamespacedName, prometheusRuleString string) (ctrl.Result, error) {
 	log := r.Log.WithValues("name", key.Name, "namespace", key.Namespace)
 
 	// Step 1: check if the object is a PrometheusRule or an AbsencePrometheusRule.
@@ -124,7 +125,7 @@ func (r *PrometheusRuleReconciler) handleObjectNotFound(ctx context.Context, key
 	// we wait until the next time when all AbsencePrometheusRules are requeued for
 	// processing (after the requeueInterval is elapsed).
 	log.V(logLevelDebug).Info("PrometheusRule no longer exists")
-	err := r.cleanUpOrphanedAbsenceAlertRules(ctx, key, "")
+	err := r.cleanUpOrphanedAbsenceAlertRules(ctx, key, "", prometheusRuleString)
 	if err != nil {
 		if !apierrors.IsNotFound(err) && !errors.Is(err, errCorrespondingAbsencePromRuleNotExists) {
 			log.Error(err, "could not clean up orphaned absence alert rules")
@@ -142,6 +143,7 @@ func (r *PrometheusRuleReconciler) reconcileObject(
 	ctx context.Context,
 	key types.NamespacedName,
 	obj *monitoringv1.PrometheusRule,
+	prometheusRuleString string,
 ) error {
 
 	log := r.Log.WithValues("name", key.Name, "namespace", key.Namespace)
@@ -176,7 +178,7 @@ func (r *PrometheusRuleReconciler) reconcileObject(
 	// elapsed).
 	if parseBool(l[labelOperatorDisable]) {
 		log.V(logLevelDebug).Info("operator disabled for this PrometheusRule")
-		err := r.cleanUpOrphanedAbsenceAlertRules(ctx, key, l[labelPrometheusServer])
+		err := r.cleanUpOrphanedAbsenceAlertRules(ctx, key, l[labelPrometheusServer], prometheusRuleString)
 		if err != nil {
 			if !apierrors.IsNotFound(err) && !errors.Is(err, errCorrespondingAbsencePromRuleNotExists) {
 				log.Error(err, "could not clean up orphaned absence alert rules")
@@ -189,7 +191,7 @@ func (r *PrometheusRuleReconciler) reconcileObject(
 	}
 
 	// Step 3: Generate the corresponding absence alert rules for this resource.
-	err := r.updateAbsenceAlertRules(ctx, obj)
+	err := r.updateAbsenceAlertRules(ctx, obj, prometheusRuleString)
 	if err == nil {
 		setReconcileGauge(key)
 		log.V(logLevelDebug).Info("successfully reconciled PrometheusRule")

--- a/main.go
+++ b/main.go
@@ -60,11 +60,13 @@ func main() {
 		probeAddr            string
 		enableLeaderElection bool
 		keepLabel            labelsMap
+		prometheusRuleString string
 	)
 	flag.BoolVar(&debug, "debug", false, "Alias for '-zap-devel' flag.")
 	// Port `9659` has been allocated for absent metrics operator: https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":9659", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&prometheusRuleString, "rule", "{{ .metadata.labels.prometheus }}-absent-metrics", "Create new prometheusRules form this template string.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -110,6 +112,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Log:       ctrl.Log.WithName("controller").WithName("prometheusrule"),
 		KeepLabel: controllers.KeepLabel(keepLabel),
+		PrometheusRuleString: prometheusRuleString,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PrometheusRule")
 		os.Exit(1)


### PR DESCRIPTION
This PR adds a `-rule` flag that takes a go template, allowing configuration of the generated absence PrometheusRule API object.
eg 
```
-rule "{{ .metadata.namespace }}-{{ .metadata.name }}-absent-metrics"
```