### PR TITLE
fix new lints

### DIFF
--- a/controllers/absence_prometheusrule.go
+++ b/controllers/absence_prometheusrule.go
@@ -52,12 +52,13 @@ func CreateAbsencePromRuleNameGenerator(tmplStr string) (AbsencePromRuleNameGene
 
 	return func(pr *monitoringv1.PrometheusRule) (string, error) {
 		// only a specific vetted subset of attributes is passed into the name template to avoid surprising behavior
+		meta := pr.ObjectMeta
 		data := map[string]any{
 			"metadata": map[string]any{
-				"annotations": pr.ObjectMeta.Annotations,
-				"labels":      pr.ObjectMeta.Labels,
-				"namespace":   pr.ObjectMeta.Namespace,
-				"name":        pr.ObjectMeta.Name,
+				"annotations": meta.Annotations,
+				"labels":      meta.Labels,
+				"namespace":   meta.Namespace,
+				"name":        meta.Name,
 			},
 		}
 


### PR DESCRIPTION
staticcheck has a new lint, QF1008, to remove superfluous references to embedded fields. In this case, changing e.g. `pr.ObjectMeta.Annotations` to `pr.Annotations` feels weird because it does not match the YAML structure, so this commit rewrites this in a way that is still clear while also making the linter happy.